### PR TITLE
use both .ico and .svg files for favicons

### DIFF
--- a/src/content/eject/b2bsaaskit.md
+++ b/src/content/eject/b2bsaaskit.md
@@ -26,6 +26,11 @@ export const prerender = true;
 </Layout>
 ```
 
+#### Favicon
+
+- replace `public/favicon.ico` with your `.ico` file
+- update `<link rel="icon" type="image/svg+xml" href={pwf} />` with your icon in `src/layouts/Layout.astro`
+
 #### Environment variables checker
 
 - `rm src/pages/app/_envCheck.ts`

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import Posthog from '../components/head/Posthog.astro';
 import '../styles/tailwind.css';
+import pwf from '../assets/b2b7.svg';
 
 export interface Props {
 	title: string;
@@ -14,7 +15,7 @@ const { title } = Astro.props;
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+		<link rel="icon" type="image/svg+xml" href={pwf} />
 		<meta name="generator" content={Astro.generator} />
 		<title>{title}</title>
 		<Posthog />


### PR DESCRIPTION
it will show prompts with friends svg where it can use it, but will fallback to favicon.ico

<img width="177" alt="image" src="https://github.com/fogbender/b2b-saaskit/assets/7026/4904649a-8f8e-4ab1-a0a2-6f76b5c6107a">

<br />

<img width="380" alt="image" src="https://github.com/fogbender/b2b-saaskit/assets/7026/03864063-1043-44f7-8e4a-53546098750f">
