### PR TITLE
Add "save as copy" button

### DIFF
--- a/src/components/app/CreatePrompt.tsx
+++ b/src/components/app/CreatePrompt.tsx
@@ -505,7 +505,8 @@ export const EditPromptControls = ({
 										.map((x) => x.trim()) ?? [],
 								template: messages,
 							};
-							if (promptId) {
+							const { submitter } = e.nativeEvent as any as { submitter: HTMLButtonElement };
+							if (promptId && submitter.name === 'save') {
 								updatePromptMutation.mutate({ promptId, ...data });
 							} else {
 								addPromptMutation.mutate(data);
@@ -593,13 +594,24 @@ export const EditPromptControls = ({
 						<fieldset className="mt-8 flex flex-col items-start gap-4">
 							{messages.length > 0 && <JsonSnippet messages={messages} />}
 							{messages.length > 0 && <CopyToClipboardBtn messages={messages} />}
+							{promptId && (
+								<button
+									className="min-w-[6rem] rounded bg-blue-500 px-4 py-2 font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+									type="submit"
+									disabled={promptIsBeingSaved}
+									name="save"
+								>
+									{promptId && (updatePromptMutation.isLoading ? 'Saving' : 'Save')}
+								</button>
+							)}
 							<button
 								className="min-w-[6rem] rounded bg-blue-500 px-4 py-2 font-medium text-white hover:bg-blue-700 disabled:opacity-50"
 								type="submit"
+								name="publish"
 								disabled={promptIsBeingSaved}
 							>
-								{promptId && (promptIsBeingSaved ? 'Saving' : 'Save')}
-								{!promptId && (promptIsBeingSaved ? 'Publishing' : 'Publish')}
+								{promptId && (addPromptMutation.isLoading ? 'Saving' : 'Save as a copy')}
+								{!promptId && (addPromptMutation.isLoading ? 'Publishing' : 'Publish')}
 							</button>
 							{promptId && (
 								<button

--- a/src/components/app/CreatePrompt.tsx
+++ b/src/components/app/CreatePrompt.tsx
@@ -259,6 +259,10 @@ export const EditPromptControls = ({
 		},
 	});
 
+	const [newIsPublic, setNewIsPublic] = useState<boolean | undefined>(undefined);
+
+	const isPublic = newIsPublic === undefined ? promptPrivacyLevel === 'public' : newIsPublic;
+
 	return (
 		<div className="mb-36 mt-4 flex flex-col gap-10">
 			<div className="flex flex-col gap-4">
@@ -578,6 +582,10 @@ export const EditPromptControls = ({
 										name="privacyLevel"
 										className="block w-full rounded-md border border-gray-300 p-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
 										defaultValue={promptPrivacyLevel}
+										onChange={(e) => {
+											const value = e.currentTarget.value as PrivacyLevel;
+											setNewIsPublic(value === 'public');
+										}}
 									>
 										<option value="public">Public (indexed by Google)</option>
 										<option value="unlisted">
@@ -610,8 +618,17 @@ export const EditPromptControls = ({
 								name="publish"
 								disabled={promptIsBeingSaved}
 							>
-								{promptId && (addPromptMutation.isLoading ? 'Saving' : 'Save as a copy')}
-								{!promptId && (addPromptMutation.isLoading ? 'Publishing' : 'Publish')}
+								{isPublic ? (
+									<>
+										{promptId && (addPromptMutation.isLoading ? 'Publishing' : 'Publish as a copy')}
+										{!promptId && (addPromptMutation.isLoading ? 'Publishing' : 'Publish')}
+									</>
+								) : (
+									<>
+										{promptId && (addPromptMutation.isLoading ? 'Saving' : 'Save as a copy')}
+										{!promptId && (addPromptMutation.isLoading ? 'Creating' : 'Create')}
+									</>
+								)}
 							</button>
 							{promptId && (
 								<button

--- a/src/components/app/CreatePrompt.tsx
+++ b/src/components/app/CreatePrompt.tsx
@@ -248,6 +248,8 @@ export const EditPromptControls = ({
 		},
 	});
 
+	const promptIsBeingSaved = addPromptMutation.isLoading || updatePromptMutation.isLoading;
+
 	const deletePromptMutation = trpc.prompts.deletePrompt.useMutation({
 		onSuccess: () => {
 			navigate(`/app/prompts`);
@@ -594,14 +596,10 @@ export const EditPromptControls = ({
 							<button
 								className="min-w-[6rem] rounded bg-blue-500 px-4 py-2 font-medium text-white hover:bg-blue-700 disabled:opacity-50"
 								type="submit"
-								disabled={addPromptMutation.isLoading || updatePromptMutation.isLoading}
+								disabled={promptIsBeingSaved}
 							>
-								{promptId ? 'Sav' : 'Publish'}
-								{addPromptMutation.isLoading || updatePromptMutation.isLoading
-									? 'ing'
-									: promptId
-									? 'e'
-									: ''}
+								{promptId && (promptIsBeingSaved ? 'Saving' : 'Save')}
+								{!promptId && (promptIsBeingSaved ? 'Publishing' : 'Publish')}
 							</button>
 							{promptId && (
 								<button


### PR DESCRIPTION
<img width="278" alt="image" src="https://github.com/fogbender/b2b-saaskit/assets/7026/f65a53b9-3786-4cd8-bd77-9e8b1eb918b5">

it changes if you are editing a public prompt
<img width="243" alt="image" src="https://github.com/fogbender/b2b-saaskit/assets/7026/c89dd39a-b550-4b08-ae45-5e4f50b44071">


Similarly for new prompts:
<img width="244" alt="image" src="https://github.com/fogbender/b2b-saaskit/assets/7026/d6b7443d-19bb-4eda-8cc8-296750cd5329">

<img width="177" alt="image" src="https://github.com/fogbender/b2b-saaskit/assets/7026/e0b0c1a2-bf09-4129-a81f-72210a4c6564">
