### PR TITLE
less padding for likes (they already have one)

### DIFF
--- a/src/components/app/Prompt.tsx
+++ b/src/components/app/Prompt.tsx
@@ -213,7 +213,9 @@ const LikesText = ({ data }: { data: { likes: number; myLike: boolean } | undefi
 	return (
 		<span className="flex">
 			<span aria-label="likes ">{data?.myLike ? '❤️' : '🤍'}</span>
-			<span className={clsx(showCounter ? '' : 'opacity-0', 'min-w-[2.5rem] px-2')}>{likes}</span>
+			<span className={clsx(showCounter ? '' : 'opacity-0', '-mr-6 min-w-[2.5rem] px-2')}>
+				{likes}
+			</span>
 		</span>
 	);
 };


### PR DESCRIPTION
before:

<img width="636" alt="image" src="https://github.com/fogbender/b2b-saaskit/assets/7026/76a4ec73-71f9-4f9c-a4b9-1b5ed5719013">

after:

<img width="564" alt="image" src="https://github.com/fogbender/b2b-saaskit/assets/7026/02014573-03bb-452c-924a-f1e27db1897c">


