### PR TITLE
Make tables sort of work on tiny screens

### DIFF
--- a/src/components/app/Nav.tsx
+++ b/src/components/app/Nav.tsx
@@ -55,8 +55,8 @@ export function AppNav() {
 
 	return (
 		<header className="bg-white px-5 py-4 shadow-sm">
-			<div className="container mx-auto flex items-center justify-between text-sm">
-				<nav className="flex flex-wrap space-x-4">
+			<div className="container mx-auto flex items-center justify-between text-xs sm:text-sm">
+				<nav className="flex flex-wrap space-x-2 sm:space-x-4">
 					<NavLink to="/app" end className={navLinkClass}>
 						Overview
 					</NavLink>

--- a/src/components/app/Prompts.tsx
+++ b/src/components/app/Prompts.tsx
@@ -88,7 +88,7 @@ export function Prompts() {
 										'opacity-50'
 								)}
 							>
-								<td className="py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 lg:pl-8">
+								<td className="break-all py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 lg:pl-8">
 									<Link
 										to={`/app/prompts/${prompt.promptId}`}
 										className="text-indigo-600 underline hover:text-indigo-900"
@@ -97,10 +97,10 @@ export function Prompts() {
 										{prompt.isPublic ? ' (Public)' : ''}
 									</Link>
 								</td>
-								<td className="px-3 py-4 text-sm text-gray-500">
+								<td className="break-all px-3 py-4 text-sm text-gray-500">
 									{prompt._meta.user?.name || prompt._meta.user?.email || prompt.userId}
 								</td>
-								<td className="relative flex gap-2 whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6 lg:pr-8">
+								<td className="relative flex flex-col items-start gap-2 whitespace-nowrap break-all py-4 pl-3 pr-4 text-right text-sm font-medium sm:flex-row sm:gap-6 sm:pr-6 lg:pr-8">
 									<Link
 										to={`/app/prompts/${prompt.promptId}/edit`}
 										className="text-indigo-600 hover:text-indigo-900"
@@ -140,17 +140,20 @@ const Table = ({ children }: { children: React.ReactNode }) => {
 							<tr>
 								<th
 									scope="col"
-									className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6 lg:pl-8"
+									className="-rotate-90 pb-8 text-sm font-semibold text-gray-900 sm:rotate-0 sm:break-all sm:pb-2 sm:text-left"
 								>
 									Prompt
 								</th>
 								<th
 									scope="col"
-									className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+									className="-rotate-90 pb-8 text-sm font-semibold text-gray-900 sm:rotate-0 sm:break-all sm:pb-2 sm:text-left"
 								>
 									Creator
 								</th>
-								<th scope="col" className="relative py-3.5 pl-3 pr-4 sm:pr-6 lg:pr-8">
+								<th
+									scope="col"
+									className="-rotate-90 pb-8 text-sm font-semibold text-gray-900 sm:rotate-0 sm:break-all sm:pb-2 sm:text-left"
+								>
 									<span className="sr-only">Delete</span>
 								</th>
 							</tr>

--- a/src/components/app/Settings.tsx
+++ b/src/components/app/Settings.tsx
@@ -204,7 +204,7 @@ export function Settings() {
 									)}
 									{!keysQuery.isLoading && keysQuery.data?.length === 0 && (
 										<tr>
-											<td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 lg:pl-8">
+											<td className="break-all py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 lg:pl-8">
 												No keys are configured,{' '}
 												<button
 													className="text-blue-500 underline hover:text-blue-700"
@@ -229,19 +229,17 @@ export function Settings() {
 													'opacity-50'
 											)}
 										>
-											<td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 lg:pl-8">
+											<td className="break-all py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6 lg:pl-8">
 												{key.keyPublic}
 											</td>
-											<td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
-												{key.keyType}
-											</td>
-											<td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+											<td className="break-all px-3 py-4 text-sm text-gray-500">{key.keyType}</td>
+											<td className="break-all px-3 py-4 text-sm text-gray-500">
 												{key.createdAt.toLocaleString()}
 											</td>
-											<td className="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+											<td className="break-all px-3 py-4 text-sm text-gray-500">
 												{key.lastUsedAt ? key.lastUsedAt.toLocaleString() : 'Never'}
 											</td>
-											<td className="relative flex justify-end gap-2 whitespace-nowrap py-4 pr-4 text-sm font-medium">
+											<td className="relative flex justify-end gap-2 break-all py-4 pr-4 text-sm font-medium">
 												<button
 													type="button"
 													className="p-1 text-indigo-600 hover:text-indigo-900 focus:outline-indigo-500"


### PR DESCRIPTION
![image](https://github.com/fogbender/b2b-saaskit/assets/41166/98106262-4da1-4173-bf09-97920b3fe950)

![image](https://github.com/fogbender/b2b-saaskit/assets/41166/40711d40-e7dd-4298-baa8-d1916ad5d95b)

Also keep nav buttons in a row on 375px-wide screen (iPhone 13 mini):

![image](https://github.com/fogbender/b2b-saaskit/assets/41166/b419c6e2-b0f2-4068-a119-83ea31060f84)
